### PR TITLE
Adds a package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "ck-pdfkit",
+    "version": "0.8.0",
+    "description": "Classkick's version of pdfkit",
+    "license": "MIT",
+    "repository": "https://github.com/classkick/ck-pdfkit/"
+}


### PR DESCRIPTION
Working on installing in classkick-web with npm instead of bower. We need to add a package.json in order to install with npm. 
