### PR TITLE
Adds a package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "ck-pdfkit",
+    "version": "0.8.0",
+    "description": "Classkick's version of pdfkit",
+    "license": "MIT",
+    "repository": "https://github.com/classkick/ck-pdfkit/"
+}


### PR DESCRIPTION
We need a package.json to install with npm instead of bower. This is a basic package.json.

Reviewers: I feel confident that this will not affect releases in any way, but wanted eyes on it in case it did. This should not affect [bower installing](https://bower.io/docs/api/#install) in any way. 